### PR TITLE
Support Pelican 3.2 and above

### DIFF
--- a/gallery.py
+++ b/gallery.py
@@ -1,6 +1,6 @@
-import logging, json, os, sys, time, Image
+import logging, json, os, sys, time
 from pelican import signals
-from PIL import ImageOps
+from PIL import ImageOps, Image
 
 """
 

--- a/gallery.py
+++ b/gallery.py
@@ -180,7 +180,7 @@ def get_galleries(generator, metadata):
 
 def register():
     # signals.article_generator_init.connect(init_gallery_plugin)
-    signals.article_generate_context.connect(get_galleries)
+    signals.article_generator_context.connect(get_galleries)
     signals.page_generator_context.connect(get_galleries)
 
 

--- a/gallery.py
+++ b/gallery.py
@@ -163,10 +163,10 @@ class Gallery():
                 if not os.path.exists(preset_dir):
                     os.makedirs(preset_dir)
         else:
-            print "You have no presets defined, please add GALLERY_PRESETS array to settings file, with at least one preset defined, see docs."
+            print("You have no presets defined, please add GALLERY_PRESETS array to settings file, with at least one preset defined, see docs.")
     
     def get_files_from_data(self):
-        print "getting files for %s" % self.absolute_src_path
+        print("getting files for %s" % self.absolute_src_path)
         from os import listdir
         from os.path import isfile, join
         return [ f for f in listdir(self.absolute_src_path) if isfile(join(self.absolute_src_path,f)) and f != ".DS_Store" ]


### PR DESCRIPTION
Update gallery.py to use new signal name. Without backward compatibility.
See note http://docs.getpelican.com/en/latest/plugins.html#list-of-signals
